### PR TITLE
Fix "constant 2435016766 overflows int32" on GOARCH=arm

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -15,7 +15,7 @@ func isBtrfs(path string) (bool, error) {
 	if err := syscall.Statfs(path, &stfs); err != nil {
 		return false, &os.PathError{Op: "statfs", Path: path, Err: err}
 	}
-	return stfs.Type == SuperMagic, nil
+	return int64(stfs.Type) == SuperMagic, nil
 }
 
 func findMountRoot(path string) (string, error) {


### PR DESCRIPTION
Fix #1
