### PR TITLE
Reduce priviliges required to query btrfs volumes

### DIFF
--- a/btrfs.go
+++ b/btrfs.go
@@ -29,6 +29,11 @@ func Open(path string, ro bool) (*FS, error) {
 	)
 	if ro {
 		dir, err = os.OpenFile(path, os.O_RDONLY|syscall.O_NOATIME, 0644)
+		if err != nil {
+			// Try without O_NOATIME as it requires ownership of the file
+			// or other priviliges
+			dir, err = os.OpenFile(path, os.O_RDONLY, 0644)
+		}
 	} else {
 		dir, err = os.Open(path)
 	}


### PR DESCRIPTION
In https://github.com/prometheus/node_exporter/issues/2632 we figured out that `O_NOATIME` was increasing the privileges needed!

From the [open man page](https://man7.org/linux/man-pages/man2/openat.2.html) 
```
O_NOATIME (since Linux 2.6.8)
              Do not update the file last access time (st_atime in the
              inode) when the file is [read(2)](https://man7.org/linux/man-pages/man2/read.2.html).

              This flag can be employed only if one of the following
              conditions is true:

              *  The effective UID of the process matches the owner UID
                 of the file.

              *  The calling process has the CAP_FOWNER capability in
                 its user namespace and the owner UID of the file has a
                 mapping in the namespace.
```