### PR TITLE
chore: Use latest commit from dennwc/ioctl to include LICENSE

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/dennwc/btrfs
 
 go 1.12
 
-require github.com/dennwc/ioctl v1.0.0
+require github.com/dennwc/ioctl v1.0.1-0.20181021180353-017804252068

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,4 @@
 github.com/dennwc/ioctl v1.0.0 h1:DsWAAjIxRqNcLn9x6mwfuf2pet3iB7aK90K4tF16rLg=
 github.com/dennwc/ioctl v1.0.0/go.mod h1:ellh2YB5ldny99SBU/VX7Nq0xiZbHphf1DrtHxxjMk0=
+github.com/dennwc/ioctl v1.0.1-0.20181021180353-017804252068 h1:K71w/n/Y74EQsKo91511t7TK35YRPrk9G+2anKYNPXk=
+github.com/dennwc/ioctl v1.0.1-0.20181021180353-017804252068/go.mod h1:ellh2YB5ldny99SBU/VX7Nq0xiZbHphf1DrtHxxjMk0=


### PR DESCRIPTION
Module github.com/dennwc/ioctl v1.0.0 dos not include the license file in a tagged release.

This facilitates the packaging for Fedora.